### PR TITLE
Add support for the cancelMoneyIn method

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -499,6 +499,16 @@ Client.prototype.getMoneyInSDD  = function (ip, _opts) {
   });
 };
 
+Client.prototype.cancelMoneyIn = function (ip, _opts) {
+  var opts = _.assign({}, _opts, {
+    version: '2.1',
+    wallet: _opts.wallet,
+    transaction: utils.stringToInteger(_opts.transactionId)
+  });
+
+  return this._request('CancelMoneyIn', ip, opts).get('CANCELMONEYIN').get('HPAY');
+};
+
 Client.prototype.getMoneyInChequeDetails  = function (ip, _opts) {
   var opts = _.assign({}, _opts, {
     version: '1.9',

--- a/lib/client.js
+++ b/lib/client.js
@@ -503,7 +503,7 @@ Client.prototype.cancelMoneyIn = function (ip, _opts) {
   var opts = _.assign({}, _opts, {
     version: '2.1',
     wallet: _opts.wallet,
-    transaction: utils.stringToInteger(_opts.transactionId)
+    transaction: utils.stringToInteger(_opts.transaction)
   });
 
   return this._request('CancelMoneyIn', ip, opts).get('CANCELMONEYIN').get('HPAY');

--- a/lib/factories/transaction-factory.js
+++ b/lib/factories/transaction-factory.js
@@ -127,7 +127,7 @@ function TransactionFactory (lemonway) {
 
   this.cancelMoneyIn = function (ip, _opts) {
     var opts = _.assign({}, {
-      transactionId: transaction.id ? transaction.id : transaction
+      transaction: transaction.id ? transaction.id : transaction
     }, _opts);
 
     return lemonway._client.cancelMoneyIn(ip, opts)

--- a/lib/factories/transaction-factory.js
+++ b/lib/factories/transaction-factory.js
@@ -125,18 +125,6 @@ function TransactionFactory (lemonway) {
       });
   };
 
-  this.cancelMoneyIn = function (ip, _opts) {
-    var opts = _.assign({}, {
-      transaction: transaction.id ? transaction.id : transaction
-    }, _opts);
-
-    return lemonway._client.cancelMoneyIn(ip, opts)
-      .bind(this)
-      .then(function (data) {
-        return new this.Transaction(data);
-      });
-  };
-
   this.getMoneyInChequeDetails = function (ip, _opts) {
     var opts = _.assign({
       after: _opts.after || 0

--- a/lib/factories/transaction-factory.js
+++ b/lib/factories/transaction-factory.js
@@ -125,6 +125,18 @@ function TransactionFactory (lemonway) {
       });
   };
 
+  this.cancelMoneyIn = function (ip, _opts) {
+    var opts = _.assign({}, {
+      transactionId: transaction.id ? transaction.id : transaction
+    }, _opts);
+
+    return lemonway._client.cancelMoneyIn(ip, opts)
+      .bind(this)
+      .then(function (data) {
+        return new this.Transaction(data);
+      });
+  };
+
   this.getMoneyInChequeDetails = function (ip, _opts) {
     var opts = _.assign({
       after: _opts.after || 0

--- a/lib/factories/wallet-factory.js
+++ b/lib/factories/wallet-factory.js
@@ -258,6 +258,19 @@ function WalletFactory (lemonway) {
       });
   };
 
+  this.cancelMoneyIn = function (ip, wallet, transaction, _opts) {
+    var opts = _.assign({}, _opts, {
+      wallet: _.get(wallet, 'id', wallet),
+      transaction: _.get(transaction, 'id', transaction)
+    });
+
+    return lemonway._client.cancelMoneyIn(ip, opts)
+      .bind(this)
+      .then(function (data) {
+        return new lemonway.Transaction.Transaction(data);
+      });
+  }
+
   this.moneyInChequeInit = function (ip, wallet, _opts) {
     var opts = _.assign({}, _opts, {
       wallet: _.get(wallet, 'id', wallet)
@@ -350,6 +363,7 @@ function WalletFactory (lemonway) {
 
 
   var instanceMethods = {
+    'cancelMoneyIn': ['cancelMoneyIn'],
     'update': ['update'],
     'moneyIn': ['moneyIn'],
     'moneyInWebInit': ['moneyInWebInit'],

--- a/lib/validation-schemas.js
+++ b/lib/validation-schemas.js
@@ -362,6 +362,13 @@ Joi.GetMoneyInSdd = function () {
   }));
 };
 
+Joi.CancelMoneyIn = function () {
+  return Joi.lemonwayBase().concat(Joi.object({
+    wallet: Joi.string().min(0).max(100).required(),
+    transaction: Joi.alternatives().try(Joi.number(), Joi.string()).required()
+  }))
+}
+
 Joi.GetMoneyInChequeDetails = function () {
   return Joi.lemonwayBase().concat(Joi.object({
     updateDate: Joi.number().required()

--- a/test/wallet/money-in-sdd.js
+++ b/test/wallet/money-in-sdd.js
@@ -11,16 +11,29 @@ var chance = new Chance();
 
 describe('money in sdd', function () {
   this.timeout(2000000);
+  var lemonway = new Lemonway(
+    process.env.LOGIN,
+    process.env.PASS,
+    process.env.ENDPOINT,
+    process.env.WK_URL,
+    { proxy: process.env.LEMONWAY_PROXY_URL }
+  );
+  var mandate;
+  var id;
+  var transaction;
 
   it('credit a wallet', function (done) {
-    var lemonway = new Lemonway(process.env.LOGIN, process.env.PASS, process.env.ENDPOINT, process.env.WK_URL);
-    var id = chance.word({ syllables: 5 });
+    id = chance.word({ syllables: 5 });
     lemonway.Wallet.create(chance.ip(), {
       id: id,
       email: chance.email(),
       firstName: chance.first(),
       lastName: chance.last(),
-      birthDate: new Date()
+      birthDate: new Date(),
+      country: 'FRA',
+      nationality: 'FRA',
+      payerOfBeneficiary: '1',
+      isCompany: false
     }).then(function (wallet) {
       return wallet.updateWalletStatus(chance.ip(), {
         status: 'KYC_2'
@@ -31,7 +44,9 @@ describe('money in sdd', function () {
           iban: 'FR1420041010050500013M02606',
           isRecurring: false
         });
-      }).then(function (mandate) {
+      }).then(function (_mandate) {
+        mandate = _mandate;
+
         return mandate.signDocumentInit(chance.ip(), wallet, {
           mobileNumber: process.env.PHONE,
           returnUrl: chance.url(),
@@ -50,10 +65,23 @@ describe('money in sdd', function () {
         });
       });
     }).then(function (transaction) {
+      transaction = transation.id;
+
       return done();
     }).catch((err) => {
       console.log(err); // Url returned by lemonway on the dev environment fail to validate SSD Mandate
       done();
     });
   });
+
+  it('cancel credit a wallet', function (done) {
+    return lemonway.Wallet.cancelMoneyIn(chance.ip(), id, transaction)
+      .then(function (transaction) {
+
+        return done();
+
+      }).catch((err) => {
+        done(err);
+      });
+    });
 });

--- a/test/wallet/money-in-sdd.js
+++ b/test/wallet/money-in-sdd.js
@@ -4,6 +4,7 @@ var open = require('open');
 var expect = require('chai').expect;
 var Promise = require('bluebird');
 var Chance = require('chance');
+var moment = require('moment');
 
 var Lemonway = require('../../');
 
@@ -29,10 +30,10 @@ describe('money in sdd', function () {
       email: chance.email(),
       firstName: chance.first(),
       lastName: chance.last(),
-      birthDate: new Date(),
+      birthdate: moment().format('DD/MM/YYYY'),
       country: 'FRA',
       nationality: 'FRA',
-      payerOfBeneficiary: '1',
+      payerOrBeneficiary: true,
       isCompany: false
     }).then(function (wallet) {
       return wallet.updateWalletStatus(chance.ip(), {
@@ -65,7 +66,7 @@ describe('money in sdd', function () {
         });
       });
     }).then(function (transaction) {
-      transaction = transation.id;
+      transaction = transaction.id;
 
       return done();
     }).catch((err) => {
@@ -75,12 +76,15 @@ describe('money in sdd', function () {
   });
 
   it('cancel credit a wallet', function (done) {
-    return lemonway.Wallet.cancelMoneyIn(chance.ip(), id, transaction)
+    lemonway.Wallet.getWalletTransHistory(chance.ip(), id)
+      .get(0)
+      .then((sdd) => lemonway.Wallet.cancelMoneyIn(chance.ip(), id, sdd.id))
       .then(function (transaction) {
+        expect(transaction.status).to.eql('6');
 
-        return done();
-
-      }).catch((err) => {
+        done();
+      })
+      .catch((err) => {
         done(err);
       });
     });


### PR DESCRIPTION
### Summary

We need the `CancelMoneyIn` method to be able to cancel SDD orders that were sent.

### Changes
The method can now be called on the Wallet factory: `lemonway.Wallet.cancelMoneyIn(ip, walletId, transactionId)`

See the documentation: http://documentation.lemonway.fr/api-en/directkit/money-in-credit-a-wallet/cancelmoneyin-cancellation-of-a-preauthorisation-request-sdd.