### PR TITLE
🚑 Set namespaceArrayElements to false

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -79,7 +79,7 @@ Client.prototype._request = function (method, ip, args, resultName) {
   var _arguments = arguments;
 
   if (!this._client) {
-    return _createSoapClient(this._endpoint, this.options)
+    return _createSoapClient(this._endpoint, { ...this.options, namespaceArrayElements: false })
       .bind(this)
       .then(function (client) {
         this._client = client;

--- a/test/wallet/get-wallet-details-batch.js
+++ b/test/wallet/get-wallet-details-batch.js
@@ -12,7 +12,7 @@ describe('getWalletDetailsBatch', function () {
   this.timeout(2000000);
 
   it('should get a batch of wallet details', function (done) {
-    const lemonway = new Lemonway(process.env.LOGIN, process.env.PASS, process.env.ENDPOINT, process.env.WK_URL, { proxy: 'https://proxy.october.eu/lemonway/staging', namespaceArrayElements: false});
+    const lemonway = new Lemonway(process.env.LOGIN, process.env.PASS, process.env.ENDPOINT, process.env.WK_URL, { proxy: 'https://proxy.october.eu/lemonway/staging' });
     const prefix = chance.integer({ min: 10, max: 99 });
     const walletIds = _.range(5).map(() => ({
       wallet: `${prefix}${chance.integer({ min: 100, max: 999 })}`,
@@ -51,7 +51,7 @@ describe('getWalletDetailsBatch', function () {
   });
 
   it('should get a batch of wallet not found errors', function (done) {
-    const lemonway = new Lemonway(process.env.LOGIN, process.env.PASS, process.env.ENDPOINT, process.env.WK_URL, { proxy: 'https://proxy.october.eu/lemonway/staging', namespaceArrayElements: false});
+    const lemonway = new Lemonway(process.env.LOGIN, process.env.PASS, process.env.ENDPOINT, process.env.WK_URL, { proxy: 'https://proxy.october.eu/lemonway/staging' });
     const prefix = chance.integer({ min: 10, max: 99 });
     const unknownWalletIds = _.range(5).map(() => ({
       wallet: `${prefix}${chance.integer({ min: 100, max: 999 })}`,
@@ -70,7 +70,7 @@ describe('getWalletDetailsBatch', function () {
   });
 
   it('should get a batch of wallet details and wallet not found errors', function (done) {
-    const lemonway = new Lemonway(process.env.LOGIN, process.env.PASS, process.env.ENDPOINT, process.env.WK_URL, { proxy: 'https://proxy.october.eu/lemonway/staging', namespaceArrayElements: false});
+    const lemonway = new Lemonway(process.env.LOGIN, process.env.PASS, process.env.ENDPOINT, process.env.WK_URL, { proxy: 'https://proxy.october.eu/lemonway/staging' });
     const prefix = chance.integer({ min: 10, max: 99 });
     const walletIds = _.range(2).map(() => ({
       wallet: `${prefix}${chance.integer({ min: 100, max: 999 })}`,


### PR DESCRIPTION
With respect to lemonway SOAP expectations.

The lemonway SOAP asks for list formatting in requests such as : 
```
<list>
  <elem/>
  <elem/>
  <elem/>
</list>
```

And the default behavior of the SOAP client we're using is : 
```
<list>
  <elem/>
</list>
<list>
  <elem/>
</list>
<list>
  <elem/>
</list>
```

In consequence, we should set the option `namespaceArrayElements: false` to meet lemonway expectations.