### PR TITLE
Update document status to reflect lemonway's api changes

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -56,7 +56,6 @@ module.exports.TRANSACTION_TYPE = {
   P2P: '2'
 };
 
-
 module.exports.DOCUMENT_TYPE = {
   ID: '0',
   PROOF_OF_ADDRESS: '1',

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -56,6 +56,7 @@ module.exports.TRANSACTION_TYPE = {
   P2P: '2'
 };
 
+
 module.exports.DOCUMENT_TYPE = {
   ID: '0',
   PROOF_OF_ADDRESS: '1',
@@ -73,11 +74,12 @@ module.exports.DOCUMENT_TYPE = {
 module.exports.DOCUMENT_STATUS = {
   RECEIVED: '1',
   VALID: '2',
-  SUSPECTED_FRAUD: '3',
+  REJECTED: '3',
   UNREADABLE: '4',
   DATE_EXPIRED: '5',
   WRONG_TYPE: '6',
-  WRONG_NAME: '7'
+  WRONG_NAME: '7',
+  DUPLICATED_DOCUMENT: '8',
 };
 
 module.exports.MANDATE_STATUS = {


### PR DESCRIPTION
### Summary

Lemonway's document statuses have changes so we need to update our constants
[Lemonway's documentation](https://documentation.lemonway.com/reference/kyc-document-status)

Closes [FC-364](https://october.atlassian.net/browse/FC-364).

### Changes

+ `lib/constants.js` update document status

### Related

+ :warning: https://github.com/o5r/api.october.eu/pull/6588

### Up next
N/A.

### Real case testing

Using the related PR in api.october.eu
- run tests api tests `npm run mocha tests/crons/pendingBankUsers`
They should fail because of your current version of lemonway

- link the current version to the dependencies in api.october.eu
  - in lemonway's directory: `npm link`
  - in api.october: `npm link lemonway`
- run tests api tests `npm run mocha tests/crons/pendingBankUsers` again
All the tests should pass

### Tree

N/A.

[FC-364]: https://october.atlassian.net/browse/FC-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ