### PR TITLE
🐛 Replace unauthorized chars in 'holder' by spaces

### DIFF
--- a/lib/factories/wallet-factory.js
+++ b/lib/factories/wallet-factory.js
@@ -312,6 +312,8 @@ function WalletFactory (lemonway) {
       wallet: _.get(wallet, 'id', wallet)
     }, _opts);
 
+    opts.holder = opts.holder.replace(/[^a-zA-Z0-9 -]/g, ' ');;
+
     return lemonway._client.registerIBAN(ip, opts)
       .bind(this)
       .then(function (data) {

--- a/test/wallet/register-iban.js
+++ b/test/wallet/register-iban.js
@@ -1,42 +1,58 @@
 'use strict';
 
-var expect = require('chai').expect;
-var Chance = require('chance');
+const expect = require('chai').expect;
+const Chance = require('chance');
 
-var Lemonway = require('../../');
+const Lemonway = require('../../');
 
-var chance = new Chance();
+const chance = new Chance();
 
-describe.only('register iban', function () {
+describe('register iban', function () {
   this.timeout(2000000);
 
-  it('registers an iban with authorized chars in holder field', function (done) {
-    var lemonway = new Lemonway(process.env.LOGIN, process.env.PASS, process.env.ENDPOINT);
-    lemonway.Wallet.get(chance.ip(), {
-      id: '106',
-      email: 'jean.dupont106@mail.com',
-    }).then(function (response) {
-      return response.wallet.registerIBAN(chance.ip(), {
-        holder: 'alphanumeric 123 and - only',
-        iban: 'FR1420041010050500013M02606'
-      });
-    }).then(function (iban) {
-      return done();
-    }).catch(done);
+  const lemonway = new Lemonway(process.env.LOGIN, process.env.PASS, process.env.ENDPOINT, process.env.WK_URL);
+  const ip = chance.ip();
+  let newWallet;
+
+  before(async function() {
+    newWallet = await lemonway.Wallet.create(ip, {
+      id: chance.word({ syllables: 5 }),
+      email: chance.email(),
+      firstName: chance.first(),
+      lastName: chance.last(),
+      birthdate: '25/05/1980',
+      payerOrBeneficiary: '1',
+      country: 'FRA',
+      isCompany: false,
+      nationality: 'FRA',
+    });
   });
 
-  it('registers an iban with unauthorized chars in holder changed in spaces', function (done) {
-    var lemonway = new Lemonway(process.env.LOGIN, process.env.PASS, process.env.ENDPOINT);
-    lemonway.Wallet.get(chance.ip(), {
-      id: '106',
-      email: 'jean.dupont106@mail.com',
-    }).then(function (response) {
-      return response.wallet.registerIBAN(chance.ip(), {
-        holder: 'unauthorized chars like _ and &.',
-        iban: 'FR1420041010050500013M02606'
-      });
-    }).then(function (iban) {
-      return done();
-    }).catch(done);
+  it('registers an iban with authorized chars in holder field', async function() {
+    const wallet = await lemonway.Wallet.get(ip, {
+      id: newWallet.id,
+    });
+
+    await wallet.wallet.registerIBAN(ip, {
+      holder: 'alphanumeric 123 and - only',
+      iban: 'FR1420041010050500013M02606'
+    });
+  });
+
+  it("registers an iban with unauthorized chars in 'holder' field replaced by spaces", async function() {
+    const wallet = await lemonway.Wallet.get(ip, {
+      id: newWallet.id,
+    });
+
+    await wallet.wallet.registerIBAN(ip, {
+      holder: 'unauthorized chars like _ and &. for example',
+      iban: 'FR1420041010050500013M02606'
+    });
+
+    const walletWithIban = await lemonway.Wallet.get(ip, {
+      id: newWallet.id,
+    });
+
+    expect(walletWithIban.wallet.ibans.at(-1).holder).to.eql('unauthorized chars like   and    for example');
   });
 });

--- a/test/wallet/register-iban.js
+++ b/test/wallet/register-iban.js
@@ -7,26 +7,36 @@ var Lemonway = require('../../');
 
 var chance = new Chance();
 
-describe('register iban', function () {
+describe.only('register iban', function () {
   this.timeout(2000000);
 
-  it('register an iban', function (done) {
+  it('registers an iban with authorized chars in holder field', function (done) {
     var lemonway = new Lemonway(process.env.LOGIN, process.env.PASS, process.env.ENDPOINT);
-    lemonway.Wallet.create(chance.ip(), {
-      id: chance.word({ syllables: 5 }),
-      email: chance.email(),
-      firstName: chance.first(),
-      lastName: chance.last(),
-      birthDate: new Date()
-    }).then(function (wallet) {
-      return wallet.registerIBAN(chance.ip(), {
-        holder: chance.first() + " " + chance.last(),
+    lemonway.Wallet.get(chance.ip(), {
+      id: '106',
+      email: 'jean.dupont106@mail.com',
+    }).then(function (response) {
+      return response.wallet.registerIBAN(chance.ip(), {
+        holder: 'alphanumeric 123 and - only',
         iban: 'FR1420041010050500013M02606'
       });
     }).then(function (iban) {
       return done();
     }).catch(done);
-
   });
 
+  it('registers an iban with unauthorized chars in holder changed in spaces', function (done) {
+    var lemonway = new Lemonway(process.env.LOGIN, process.env.PASS, process.env.ENDPOINT);
+    lemonway.Wallet.get(chance.ip(), {
+      id: '106',
+      email: 'jean.dupont106@mail.com',
+    }).then(function (response) {
+      return response.wallet.registerIBAN(chance.ip(), {
+        holder: 'unauthorized chars like _ and &.',
+        iban: 'FR1420041010050500013M02606'
+      });
+    }).then(function (iban) {
+      return done();
+    }).catch(done);
+  });
 });


### PR DESCRIPTION
## Summary
Lemonway API does not accept most special chars anymore in `holder` field when registering an IBAN. This PR replaces all chars other than letters, digits, spaces and dashes (`-`) by spaces.

Closes [POF-407](https://october.atlassian.net/browse/POF-407)

## Changes
- `lib/factories/wallet-factory.js`: replace unauthorized chars by spaces in `holder` field.
- `test/wallet/register-iban.js`: rewrite test with async/await + add new test

## Related
- [ ] Upcoming PR on `api.october.eu` to bump lemonway package.

## Real-case testing 
- Clone lemonway repo, checkout this branch, launch `npm install`
- In api.october.eu :
  - change `package.json` to link to local lemonway package: `"lemonway": "file:./path/to/lemonway",`  
  - launch `npm install` to take this change into account
  - since there's no Lemonway VPN anymore, use this in your `.env` file: `ENABLE_LEMONWAY_PROXY=0` 
- **Connect to October gateway** on VPN to be able to connect lemonway sandbox API
- Launch the local app and api:
  - Create a project in the app associated to a business whose name contains a special char like `#`. In project tab, click "new project". You can use a json file to easily create the project.
  - Fill in the next tabs: "Description", "Conditions", "Submit" (use http://randomiban.com/?country=France to generate the iban)
  - In "Submit" tab, click "Save" at the top and then "Validate" at the bottom of the page. Without the fix in this PR, this should return a `bad input data` error from Lemonway. This error is corrected by this fix.
  - Check in [lemonway sandbox](https://sb-bo.lemonway.com/lendix/sign-in) that the Iban was added with `titulaire` field having special chars are replaced by spaces.




[POF-407]: https://october.atlassian.net/browse/POF-407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ