### PR TITLE
nationality was actually not required

### DIFF
--- a/lib/validation-schemas.js
+++ b/lib/validation-schemas.js
@@ -34,7 +34,7 @@ Joi.RegisterWallet = function () {
     companyDescription: Joi.string().min(1).max(256),
     companyIdentificationNumber: Joi.string().min(1).max(256),
     isDebtor: Joi.string().valid(['0', '1']),
-    nationality: Joi.string().max(19).required(),
+    nationality: Joi.string().max(19),
     birthcity: Joi.string().max(140),
     birthcountry: Joi.string().length(3),
     payerOrBeneficiary: Joi.string().valid(['0', '1', '2']).required(),


### PR DESCRIPTION
# Changes

When creating a wallet, `nationality` is marked as required in the documentation but is actually not used when creating borrower wallets