### PR TITLE
🔒 Remove joi to fix hoek vulnerability

### DIFF
--- a/lib/validation-schemas.js
+++ b/lib/validation-schemas.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var _ = require('lodash');
-var BaseJoi = require('joi');
-var Joi = BaseJoi.extend(require('joi-date-extensions'));
+var BaseJoi = require('@hapi/joi');
+var Joi = BaseJoi.extend(require('@hapi/joi-date'));
 
 var constants = require('./constants');
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Promise = require('bluebird');
-var Joi = require('joi');
+var Joi = require('@hapi/joi');
 
 var _validate = Promise.promisify(Joi.validate, { context: Joi });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
+        "@hapi/joi": "^17.1.1",
+        "@hapi/joi-date": "^2.0.1",
         "bluebird": "3.5.1",
         "credit-card-type": "7.0.0",
-        "joi": "13.6.0",
-        "joi-date-extensions": "1.2.0",
         "lodash": "4.17.21",
         "moment": "2.29.4",
         "soap": "1.0.0"
@@ -23,6 +23,60 @@
         "chance": "^1.0.16",
         "mocha": "^10.2.0",
         "open": "^8.4.2"
+      }
+    },
+    "node_modules/@hapi/address": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
+      "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
+      "deprecated": "Moved to 'npm install @sideway/address'",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==",
+      "deprecated": "Moved to 'npm install @sideway/formula'"
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "node_modules/@hapi/joi": {
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz",
+      "integrity": "sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==",
+      "deprecated": "Switch to 'npm install joi'",
+      "dependencies": {
+        "@hapi/address": "^4.0.1",
+        "@hapi/formula": "^2.0.0",
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/pinpoint": "^2.0.0",
+        "@hapi/topo": "^5.0.0"
+      }
+    },
+    "node_modules/@hapi/joi-date": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi-date/-/joi-date-2.0.1.tgz",
+      "integrity": "sha512-8be8JUEC8Wm1Do3ryJy+TXmkAL13b2JwXn7gILBoor8LopY/M+hJskodzOOxfJdckkfWnbmbnMEyJW3d/gZMfA==",
+      "dependencies": {
+        "moment": "2.x.x"
+      }
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q=="
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -680,15 +734,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/hoek": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
-      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -801,54 +846,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/isemail": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.3.tgz",
-      "integrity": "sha512-5xbsG5wYADIcB+mfLsd+nst1V/D+I7EU7LEZPo2GOIMu4JzfcRs5yQoypP4avA7QtUqgxYLKBYNv4IdzBmbhdw==",
-      "dependencies": {
-        "punycode": "2.x.x"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/isemail/node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/joi": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.6.0.tgz",
-      "integrity": "sha512-E4QB0yRgEa6ZZKcSHJuBC+QeAwy+akCG0Bsa9edLqljyhlr+GuGDSmXYW1q7sj/FuAPy+ECUI3evVtK52tVfwg==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dependencies": {
-        "hoek": "5.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
-    "node_modules/joi-date-extensions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/joi-date-extensions/-/joi-date-extensions-1.2.0.tgz",
-      "integrity": "sha512-rXuz2yGx/0TnG8rDBv5bqryOD7g6BvAYEs2BVt0yPWZsO1YiQd4mtHGQ4mqWt/ly/G47+ZRo/jxy02G2iACJHg==",
-      "deprecated": "This module has moved and is now available at @hapi/joi-date. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "dependencies": {
-        "moment": "2.x.x"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      },
-      "peerDependencies": {
-        "joi": ">=10.3.0"
       }
     },
     "node_modules/js-md4": {
@@ -1283,18 +1280,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/topo": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
-      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dependencies": {
-        "hoek": "5.x.x"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -1433,6 +1418,57 @@
     }
   },
   "dependencies": {
+    "@hapi/address": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
+      "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@hapi/formula": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
+    },
+    "@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "@hapi/joi": {
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz",
+      "integrity": "sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==",
+      "requires": {
+        "@hapi/address": "^4.0.1",
+        "@hapi/formula": "^2.0.0",
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/pinpoint": "^2.0.0",
+        "@hapi/topo": "^5.0.0"
+      }
+    },
+    "@hapi/joi-date": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi-date/-/joi-date-2.0.1.tgz",
+      "integrity": "sha512-8be8JUEC8Wm1Do3ryJy+TXmkAL13b2JwXn7gILBoor8LopY/M+hJskodzOOxfJdckkfWnbmbnMEyJW3d/gZMfA==",
+      "requires": {
+        "moment": "2.x.x"
+      }
+    },
+    "@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q=="
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@xmldom/xmldom": {
       "version": "0.8.10",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
@@ -1921,11 +1957,6 @@
       "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
       "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g=="
     },
-    "hoek": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
-      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2002,39 +2033,6 @@
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0"
-      }
-    },
-    "isemail": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.3.tgz",
-      "integrity": "sha512-5xbsG5wYADIcB+mfLsd+nst1V/D+I7EU7LEZPo2GOIMu4JzfcRs5yQoypP4avA7QtUqgxYLKBYNv4IdzBmbhdw==",
-      "requires": {
-        "punycode": "2.x.x"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-        }
-      }
-    },
-    "joi": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.6.0.tgz",
-      "integrity": "sha512-E4QB0yRgEa6ZZKcSHJuBC+QeAwy+akCG0Bsa9edLqljyhlr+GuGDSmXYW1q7sj/FuAPy+ECUI3evVtK52tVfwg==",
-      "requires": {
-        "hoek": "5.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
-      }
-    },
-    "joi-date-extensions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/joi-date-extensions/-/joi-date-extensions-1.2.0.tgz",
-      "integrity": "sha512-rXuz2yGx/0TnG8rDBv5bqryOD7g6BvAYEs2BVt0yPWZsO1YiQd4mtHGQ4mqWt/ly/G47+ZRo/jxy02G2iACJHg==",
-      "requires": {
-        "moment": "2.x.x"
       }
     },
     "js-md4": {
@@ -2337,14 +2335,6 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
-      }
-    },
-    "topo": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
-      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
-      "requires": {
-        "hoek": "5.x.x"
       }
     },
     "type-detect": {

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   },
   "homepage": "https://github.com/Lendix/lemonway#readme",
   "dependencies": {
+    "@hapi/joi": "^17.1.1",
+    "@hapi/joi-date": "^2.0.1",
     "bluebird": "3.5.1",
     "credit-card-type": "7.0.0",
-    "joi": "13.6.0",
-    "joi-date-extensions": "1.2.0",
     "lodash": "4.17.21",
     "moment": "2.29.4",
     "soap": "1.0.0"


### PR DESCRIPTION
### Summary

`joi` is deprecated and one of it's dependencies is vulnerable (`hoek` https://github.com/o5r/api.october.eu/security/dependabot/110)
In this PR I'm replacing `joi` with `hapi/joi`.

Related to https://github.com/o5r/api.october.eu/pull/8169

### Changes

+ Remove `joi` from `package.json`
+ Add @hapi/joi instead
+ Update imports in `lib/validator` and `lib/validation-schemas`
