### PR TITLE
🐛 Fix "Cannot read property HPAY of null"

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -115,13 +115,45 @@ Client.prototype._request = function (method, ip, args, resultName) {
     });
 };
 
+Client.prototype._extractTransaction = function (result) {
+  const transaction = result['TRANS'];
+
+  if (transaction === null || transaction === undefined) {
+    return {};
+  }
+
+  const value = transaction['HPAY'];
+
+  if (value === null || value === undefined) {
+    return {};
+  }
+
+  return value;
+}
+
+Client.prototype._extractTransactionList = function (results) {
+  const transactions = results['TRANS'];
+
+  if (transactions === null || transactions === undefined) {
+    return [];
+  }
+
+  const value = transactions['HPAY'];
+
+  if (value === null || value === undefined) {
+    return [];
+  }
+
+  return value;
+}
+
 Client.prototype.fastPay = function (ip, _opts) {
   var opts = _.assign({}, _opts, {
     amount: typeof _opts === 'string' ? _opts : utils.numberToFixed(_opts.amount),
     version: '1.2'
   });
 
-  return this._request('FastPay', ip, opts).get('TRANS').get('HPAY')
+  return this._request('FastPay', ip, opts).then(this._extractTransaction)
 };
 
 Client.prototype.registerWallet = function (ip, _opts) {
@@ -243,7 +275,7 @@ Client.prototype.moneyIn = function (ip, _opts) {
     opts.cardType = utils.cardNumberToType(_opts.cardNumber);
   }
 
-  return this._request('MoneyIn', ip, opts).get('TRANS').get('HPAY');
+  return this._request('MoneyIn', ip, opts).then(this._extractTransaction);
 };
 
 Client.prototype.moneyIn3DInit = function (ip, _opts) {
@@ -326,7 +358,7 @@ Client.prototype.moneyInWithCardId = function (ip, _opts) {
     wkToken: _opts.token
   });
 
-  return this._request('MoneyInWithCardId', ip, opts, 'MoneyInResult').get('TRANS').get('HPAY');
+  return this._request('MoneyInWithCardId', ip, opts, 'MoneyInResult').then(this._extractTransaction);
 };
 
 Client.prototype.moneyInValidate = function (ip, _opts) {
@@ -340,7 +372,7 @@ Client.prototype.sendPayment = function (ip, _opts) {
     amount: utils.numberToFixed(_opts.amount)
   });
 
-  return this._request('SendPayment', ip, opts).get('TRANS').get('HPAY');
+  return this._request('SendPayment', ip, opts).then(this._extractTransaction);
 };
 
 Client.prototype.registerIBAN = function (ip, _opts) {
@@ -368,13 +400,13 @@ Client.prototype.moneyOut = function (ip, _opts) {
     autoCommission: utils.boolToString(_opts.autoCommission)
   });
 
-  return this._request('MoneyOut', ip, opts).get('TRANS').get('HPAY');
+  return this._request('MoneyOut', ip, opts).then(this._extractTransaction);
 };
 
 Client.prototype.getPaymentDetails = function (ip, _opts) {
   var opts = _.assign({}, _opts);
 
-  return this._request('GetPaymentDetails', ip, opts).get('TRANS').get('HPAY');
+  return this._request('GetPaymentDetails', ip, opts).then(this._extractTransactionList);
 };
 
 Client.prototype.getMoneyInTransDetails = function (ip, _opts) {
@@ -384,7 +416,7 @@ Client.prototype.getMoneyInTransDetails = function (ip, _opts) {
     endDate: utils.dateToUnix(_opts.to)
   });
 
-  return this._request('GetMoneyInTransDetails', ip, opts).get('TRANS').get('HPAY');
+  return this._request('GetMoneyInTransDetails', ip, opts).then(this._extractTransactionList);
 };
 
 Client.prototype.getMoneyOutTransDetails = function (ip, _opts) {
@@ -392,7 +424,7 @@ Client.prototype.getMoneyOutTransDetails = function (ip, _opts) {
     version: '1.4'
   });
 
-  return this._request('GetMoneyOutTransDetails', ip, opts).get('TRANS').get('HPAY');
+  return this._request('GetMoneyOutTransDetails', ip, opts).then(this._extractTransactionList);
 };
 
 Client.prototype.uploadFile = function (ip, _opts) {
@@ -440,7 +472,7 @@ Client.prototype.getMoneyInIBANDetails = function (ip, _opts) {
     updateDate: utils.dateToUnix(_opts.from) || 0
   });
 
-  return this._request('GetMoneyInIBANDetails', ip, opts).get('TRANS').get('HPAY');
+  return this._request('GetMoneyInIBANDetails', ip, opts).then(this._extractTransactionList);
 };
 
 Client.prototype.refundMoneyIn = function (ip, _opts) {
@@ -449,7 +481,7 @@ Client.prototype.refundMoneyIn = function (ip, _opts) {
     version: '1.2'
   });
 
-  return this._request('RefundMoneyIn', ip, opts).get('TRANS').get('HPAY');
+  return this._request('RefundMoneyIn', ip, opts).then(this._extractTransaction);
 };
 
 Client.prototype.getBalances = function (ip, _opts) {
@@ -525,7 +557,7 @@ Client.prototype.moneyInSDDInit = function (ip, _opts) {
     collectionDate: utils.dateToDayString(_opts.collectionDate)
   });
 
-  return this._request('MoneyInSddInit', ip, opts).get('TRANS').get('HPAY');
+  return this._request('MoneyInSddInit', ip, opts).then(this._extractTransaction);
 };
 
 Client.prototype.getMoneyInSDD  = function (ip, _opts) {
@@ -557,7 +589,7 @@ Client.prototype.getMoneyInChequeDetails  = function (ip, _opts) {
     updateDate: utils.dateToUnix(_opts.from) || 0
   });
 
-  return this._request('GetMoneyInChequeDetails', ip, opts).get('TRANS').get('HPAY');
+  return this._request('GetMoneyInChequeDetails', ip, opts).then(this._extractTransactionList);
 };
 
 Client.prototype.getWalletTransHistory  = function (ip, _opts) {
@@ -574,13 +606,7 @@ Client.prototype.getWalletTransHistory  = function (ip, _opts) {
     opts.endDate = utils.dateToUnix(_opts.to)
   }
 
-  return this._request('GetWalletTransHistory', ip, opts).get('TRANS').then(results => {
-     if (_.get(results, 'HPAY')) {
-       return _.get(results, 'HPAY')
-     }
-
-    return [];
-  });
+  return this._request('GetWalletTransHistory', ip, opts).then(this._extractTransactionList);
 };
 
 Client.prototype.getChargebacks  = function (ip, _opts) {
@@ -589,7 +615,7 @@ Client.prototype.getChargebacks  = function (ip, _opts) {
     updateDate: utils.dateToUnix(_opts.from) || 0
   });
 
-  return this._request('GetChargebacks', ip, opts).get('TRANS').get('HPAY');
+  return this._request('GetChargebacks', ip, opts).then(this._extractTransactionList);
 };
 
 Client.prototype.moneyInChequeInit  = function (ip, _opts) {
@@ -600,7 +626,7 @@ Client.prototype.moneyInChequeInit  = function (ip, _opts) {
     autoCommission: utils.boolToString(_opts.autoCommission)
   });
 
-  return this._request('MoneyInChequeInit', ip, opts).get('TRANS').get('HPAY');
+  return this._request('MoneyInChequeInit', ip, opts).then(this._extractTransaction);
 };
 
 Client.prototype.createVCC = function (ip, _opts) {
@@ -608,13 +634,13 @@ Client.prototype.createVCC = function (ip, _opts) {
     amount: utils.numberToFixed(_opts.amountVCC)
   }, _opts);
 
-  return this._request('CreateVCC', ip, opts).get('TRANS').get('HPAY');
+  return this._request('CreateVCC', ip, opts).then(this._extractTransaction);
 };
 
 Client.prototype.moneyInNeosurf  = function (ip, _opts) {
   var opts = _.assign({}, _opts);
 
-  return this._request('MoneyInNeosurf', ip, opts).get('TRANS').get('HPAY');
+  return this._request('MoneyInNeosurf', ip, opts).then(this._extractTransaction);
 };
 
 Client.prototype.signDocumentInit = function (ip, _opts) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -115,45 +115,13 @@ Client.prototype._request = function (method, ip, args, resultName) {
     });
 };
 
-Client.prototype._extractTransaction = function (result) {
-  const transaction = result['TRANS'];
-
-  if (transaction === null || transaction === undefined) {
-    return {};
-  }
-
-  const value = transaction['HPAY'];
-
-  if (value === null || value === undefined) {
-    return {};
-  }
-
-  return value;
-}
-
-Client.prototype._extractTransactionList = function (results) {
-  const transactions = results['TRANS'];
-
-  if (transactions === null || transactions === undefined) {
-    return [];
-  }
-
-  const value = transactions['HPAY'];
-
-  if (value === null || value === undefined) {
-    return [];
-  }
-
-  return value;
-}
-
 Client.prototype.fastPay = function (ip, _opts) {
   var opts = _.assign({}, _opts, {
     amount: typeof _opts === 'string' ? _opts : utils.numberToFixed(_opts.amount),
     version: '1.2'
   });
 
-  return this._request('FastPay', ip, opts).then(this._extractTransaction)
+  return this._request('FastPay', ip, opts).then(_extractTransaction)
 };
 
 Client.prototype.registerWallet = function (ip, _opts) {
@@ -275,7 +243,7 @@ Client.prototype.moneyIn = function (ip, _opts) {
     opts.cardType = utils.cardNumberToType(_opts.cardNumber);
   }
 
-  return this._request('MoneyIn', ip, opts).then(this._extractTransaction);
+  return this._request('MoneyIn', ip, opts).then(_extractTransaction);
 };
 
 Client.prototype.moneyIn3DInit = function (ip, _opts) {
@@ -358,7 +326,7 @@ Client.prototype.moneyInWithCardId = function (ip, _opts) {
     wkToken: _opts.token
   });
 
-  return this._request('MoneyInWithCardId', ip, opts, 'MoneyInResult').then(this._extractTransaction);
+  return this._request('MoneyInWithCardId', ip, opts, 'MoneyInResult').then(_extractTransaction);
 };
 
 Client.prototype.moneyInValidate = function (ip, _opts) {
@@ -372,7 +340,7 @@ Client.prototype.sendPayment = function (ip, _opts) {
     amount: utils.numberToFixed(_opts.amount)
   });
 
-  return this._request('SendPayment', ip, opts).then(this._extractTransaction);
+  return this._request('SendPayment', ip, opts).then(_extractTransaction);
 };
 
 Client.prototype.registerIBAN = function (ip, _opts) {
@@ -400,13 +368,13 @@ Client.prototype.moneyOut = function (ip, _opts) {
     autoCommission: utils.boolToString(_opts.autoCommission)
   });
 
-  return this._request('MoneyOut', ip, opts).then(this._extractTransaction);
+  return this._request('MoneyOut', ip, opts).then(_extractTransaction);
 };
 
 Client.prototype.getPaymentDetails = function (ip, _opts) {
   var opts = _.assign({}, _opts);
 
-  return this._request('GetPaymentDetails', ip, opts).then(this._extractTransactionList);
+  return this._request('GetPaymentDetails', ip, opts).then(_extractTransactionList);
 };
 
 Client.prototype.getMoneyInTransDetails = function (ip, _opts) {
@@ -416,7 +384,7 @@ Client.prototype.getMoneyInTransDetails = function (ip, _opts) {
     endDate: utils.dateToUnix(_opts.to)
   });
 
-  return this._request('GetMoneyInTransDetails', ip, opts).then(this._extractTransactionList);
+  return this._request('GetMoneyInTransDetails', ip, opts).then(_extractTransactionList);
 };
 
 Client.prototype.getMoneyOutTransDetails = function (ip, _opts) {
@@ -424,7 +392,7 @@ Client.prototype.getMoneyOutTransDetails = function (ip, _opts) {
     version: '1.4'
   });
 
-  return this._request('GetMoneyOutTransDetails', ip, opts).then(this._extractTransactionList);
+  return this._request('GetMoneyOutTransDetails', ip, opts).then(_extractTransactionList);
 };
 
 Client.prototype.uploadFile = function (ip, _opts) {
@@ -472,7 +440,7 @@ Client.prototype.getMoneyInIBANDetails = function (ip, _opts) {
     updateDate: utils.dateToUnix(_opts.from) || 0
   });
 
-  return this._request('GetMoneyInIBANDetails', ip, opts).then(this._extractTransactionList);
+  return this._request('GetMoneyInIBANDetails', ip, opts).then(_extractTransactionList);
 };
 
 Client.prototype.refundMoneyIn = function (ip, _opts) {
@@ -481,7 +449,7 @@ Client.prototype.refundMoneyIn = function (ip, _opts) {
     version: '1.2'
   });
 
-  return this._request('RefundMoneyIn', ip, opts).then(this._extractTransaction);
+  return this._request('RefundMoneyIn', ip, opts).then(_extractTransaction);
 };
 
 Client.prototype.getBalances = function (ip, _opts) {
@@ -557,7 +525,7 @@ Client.prototype.moneyInSDDInit = function (ip, _opts) {
     collectionDate: utils.dateToDayString(_opts.collectionDate)
   });
 
-  return this._request('MoneyInSddInit', ip, opts).then(this._extractTransaction);
+  return this._request('MoneyInSddInit', ip, opts).then(_extractTransaction);
 };
 
 Client.prototype.getMoneyInSDD  = function (ip, _opts) {
@@ -589,7 +557,7 @@ Client.prototype.getMoneyInChequeDetails  = function (ip, _opts) {
     updateDate: utils.dateToUnix(_opts.from) || 0
   });
 
-  return this._request('GetMoneyInChequeDetails', ip, opts).then(this._extractTransactionList);
+  return this._request('GetMoneyInChequeDetails', ip, opts).then(_extractTransactionList);
 };
 
 Client.prototype.getWalletTransHistory  = function (ip, _opts) {
@@ -606,7 +574,7 @@ Client.prototype.getWalletTransHistory  = function (ip, _opts) {
     opts.endDate = utils.dateToUnix(_opts.to)
   }
 
-  return this._request('GetWalletTransHistory', ip, opts).then(this._extractTransactionList);
+  return this._request('GetWalletTransHistory', ip, opts).then(_extractTransactionList);
 };
 
 Client.prototype.getChargebacks  = function (ip, _opts) {
@@ -615,7 +583,7 @@ Client.prototype.getChargebacks  = function (ip, _opts) {
     updateDate: utils.dateToUnix(_opts.from) || 0
   });
 
-  return this._request('GetChargebacks', ip, opts).then(this._extractTransactionList);
+  return this._request('GetChargebacks', ip, opts).then(_extractTransactionList);
 };
 
 Client.prototype.moneyInChequeInit  = function (ip, _opts) {
@@ -626,7 +594,7 @@ Client.prototype.moneyInChequeInit  = function (ip, _opts) {
     autoCommission: utils.boolToString(_opts.autoCommission)
   });
 
-  return this._request('MoneyInChequeInit', ip, opts).then(this._extractTransaction);
+  return this._request('MoneyInChequeInit', ip, opts).then(_extractTransaction);
 };
 
 Client.prototype.createVCC = function (ip, _opts) {
@@ -634,13 +602,13 @@ Client.prototype.createVCC = function (ip, _opts) {
     amount: utils.numberToFixed(_opts.amountVCC)
   }, _opts);
 
-  return this._request('CreateVCC', ip, opts).then(this._extractTransaction);
+  return this._request('CreateVCC', ip, opts).then(_extractTransaction);
 };
 
 Client.prototype.moneyInNeosurf  = function (ip, _opts) {
   var opts = _.assign({}, _opts);
 
-  return this._request('MoneyInNeosurf', ip, opts).then(this._extractTransaction);
+  return this._request('MoneyInNeosurf', ip, opts).then(_extractTransaction);
 };
 
 Client.prototype.signDocumentInit = function (ip, _opts) {
@@ -662,3 +630,35 @@ Client.prototype.getWizypayAds  = function (ip, _opts) {
 };
 
 module.exports = Client;
+
+function _extractTransaction(result) {
+  const transaction = result['TRANS'];
+
+  if (transaction === null || transaction === undefined) {
+    return {};
+  }
+
+  const value = transaction['HPAY'];
+
+  if (value === null || value === undefined) {
+    return {};
+  }
+
+  return value;
+}
+
+function _extractTransactionList(results) {
+  const transactions = results['TRANS'];
+
+  if (transactions === null || transactions === undefined) {
+    return [];
+  }
+
+  const value = transactions['HPAY'];
+
+  if (value === null || value === undefined) {
+    return [];
+  }
+
+  return value;
+}


### PR DESCRIPTION
Fix https://october.atlassian.net/browse/POF-944

Provides a safer way to extract a single transaction or a transaction list from SOAP Lemonway results.

Test : 
- add LW credentials from your local `.env` of the API to `test/index.js`
- in `test/get-money-in.js`, add the following in first test
```
  const start = moment().subtract(1, 'day').toDate();
  const end = moment().toDate();

    lemonway.Transaction.getMoneyInTransDetails(chance.ip(), {
        from: start,
        to: end,
      })
      .then(function (transactions) {
        return done();
      }).catch(done);
```
- without the fix, the test will crash with `Cannot read property HPAY of null`
- with the fix, the test will pass