### PR TITLE
🚑  Replace transaction deprecated field status with int_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ opts.walletUa | string | false | Client user agent
   * amazonGiftCode -> `string|undefined`
   * message -> `string|undefined`
   * status -> `string|undefined`
+  * intStatus -> `string|undefined`
   * IBANUsed -> `string|undefined`
   * lemonwayMessage -> `string|undefined`
   * bankReference -> `string|undefined`

--- a/lib/client.js
+++ b/lib/client.js
@@ -562,7 +562,7 @@ Client.prototype.getMoneyInChequeDetails  = function (ip, _opts) {
 
 Client.prototype.getWalletTransHistory  = function (ip, _opts) {
   var opts = {
-    version: '2.0',
+    version: '2.2',
     wallet: _opts.wallet
   };
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -41,6 +41,14 @@ module.exports.TRANSACTION_STATUS = {
   PENDING_VALIDATION: '16'
 };
 
+module.exports.TRANSACTION_INT_STATUS = {
+  SUCCESS: '0',
+  IN_PROGRESS: '4',
+  ERROR: '6',
+  CANCELLATION_SUCCESS: '7',
+  PENDING_VALIDATION: '16'
+};
+
 module.exports.TRANSACTION_METHOD = {
   CARD: '0',
   INCOMING_WIRE: '1',

--- a/lib/factories/transaction-factory.js
+++ b/lib/factories/transaction-factory.js
@@ -21,6 +21,7 @@ function TransactionFactory (lemonway) {
     this.commission = parseFloat(_.get(data, 'COM'));
     this.comment = _.get(data, 'MSG');
     this.status = _.get(data, 'STATUS');
+    this.intStatus = _.get(data, 'INT_STATUS');
     this.isCard = !!_.get(data, 'EXTRA');
     this.is3DS = _.get(data, 'EXTRA.IS3DS') == '1';
     this.cardCountry = _.get(data, 'EXTRA.CTRY');


### PR DESCRIPTION
We've seen transactions having status `1` when fetching them using `getWalletTransHistory`.
This may come from the depreciation of the status field of Transaction model.

Documentation states `STATUS (deprecated, use INT_STATUS instead)`, let's use `INT_STATUS` then !

Closes POF-1047